### PR TITLE
Cleanup dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,8 @@ android {
 
 dependencies {
     compile 'com.android.support:support-annotations:23.3.0'
-    compile 'com.android.support.test:runner:0.5'
-    compile 'com.android.support.test:rules:0.5'
     compile 'com.android.support.test.espresso:espresso-intents:2.2.2'
-    compile 'com.android.support.test.espresso:espresso-core:2.2'
+    compile 'com.android.support.test.espresso:espresso-core:2.2.2'
     compile('com.android.support.test.espresso:espresso-contrib:2.2') {
         exclude module: 'support-annotations'
         exclude module: 'support-v4'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:23.3.0'
+    compile 'com.android.support:support-annotations:23.4.0'
     compile 'com.android.support.test.espresso:espresso-intents:2.2.2'
     compile 'com.android.support.test.espresso:espresso-core:2.2.2'
     compile('com.android.support.test.espresso:espresso-contrib:2.2') {


### PR DESCRIPTION
We don't need to specify runner and rules. They are already included in espresso-core. Also bump core to 2.2.2 to match intents and contrib.
