### PR TITLE
Dm/set language level

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 10
@@ -26,7 +26,7 @@ android {
 
 dependencies {
 
-    compile 'com.android.support:support-annotations:25.0.0'
+    compile 'com.android.support:support-annotations:25.1.0'
     compile 'com.android.support.test.espresso:espresso-intents:2.2.2'
     compile 'com.android.support.test.espresso:espresso-core:2.2.2'
     compile('com.android.support.test.espresso:espresso-contrib:2.2') {

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ android {
         exclude 'LICENSE.txt'
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
     }
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
My project uses retrolambda, but with library version at java 8 doesn't compile.  This library requires no java 8 features, so let's move it back to java 7 to prevent this problem for others.

I'm curious if anyone else can reproduce this issue on another project.